### PR TITLE
Ganache support for testwallet

### DIFF
--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -18,6 +18,22 @@ export const SUPPORTED_CHAINS: IChainData[] = [
     },
   },
   {
+    name: "Ethereum Local",
+    short_name: "gan",
+    chain: "ETH",
+    network: "ganache",
+    chain_id: 9001,
+    network_id: 9001,
+    rpc_url: process.env.REACT_APP_INFURA_PROJECT_ID!,
+    native_currency: {
+      symbol: "ETH",
+      name: "Ether",
+      decimals: "18",
+      contractAddress: "",
+      balance: "",
+    },
+  },
+  {
     name: "Ethereum Ropsten",
     short_name: "rop",
     chain: "ETH",

--- a/src/constants/default.ts
+++ b/src/constants/default.ts
@@ -8,4 +8,5 @@ export const ROPSTEN_CHAIN_ID = 3;
 export const RINKEBY_CHAIN_ID = 4;
 export const GOERLI_CHAIN_ID = 5;
 export const KOVAN_CHAIN_ID = 42;
-export const DEFAULT_CHAIN_ID = KOVAN_CHAIN_ID;
+export const LOCAL_CHAIN_ID = 9001;
+export const DEFAULT_CHAIN_ID = LOCAL_CHAIN_ID;

--- a/src/helpers/utilities.ts
+++ b/src/helpers/utilities.ts
@@ -111,7 +111,7 @@ export function getChainData(chainId: number): IChainData {
     throw new Error("ChainId missing or not supported");
   }
 
-  const API_KEY = (process.env.REACT_APP_INFURA_PROJECT_ID as string).split('/').slice(-1)[0];
+  const API_KEY = (process.env.REACT_APP_INFURA_PROJECT_ID as string).split("/").slice(-1)[0];
 
   if (!API_KEY) {
     throw new Error("Environment variable REACT_APP_INFURA_PROJECT_ID is not set");


### PR DESCRIPTION
@aqualen originally implemented this, but the branch had another dirty commit on it so just cleaning things up here and also using an environment variable for the localhost rpc url.

Endows the test wallet with support for talking to local ganache chain.